### PR TITLE
Rename the triangles and vertices interface size() method to return an int.

### DIFF
--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -69,7 +69,7 @@ public class Meshes
 			p.move( v );
 
 		for ( int d = 0; d < 3; d++ )
-			p.setPosition( p.getDoublePosition( d ) / m.vertices().size(), d );
+			p.setPosition( p.getDoublePosition( d ) / m.vertices().sizel(), d );
 
 		return p;
 	}
@@ -366,7 +366,7 @@ public class Meshes
 	public static void scale( final Mesh mesh, final double[] scale )
 	{
 		final Vertices vertices = mesh.vertices();
-		final long nVertices = vertices.size();
+		final long nVertices = vertices.sizel();
 		for ( long i = 0; i < nVertices; i++ )
 		{
 			final double x = vertices.x( i );

--- a/src/main/java/net/imglib2/mesh/alg/MeshConnectedComponents.java
+++ b/src/main/java/net/imglib2/mesh/alg/MeshConnectedComponents.java
@@ -36,7 +36,7 @@ public class MeshConnectedComponents
 	{
 		final Triangles triangles = mesh.triangles();
 		final Vertices vertices = mesh.vertices();
-		final int nVertices = ( int ) vertices.size();
+		final int nVertices = ( int ) vertices.sizel();
 
 		final TIntObjectHashMap< TIntArrayList > map = triangleMap( mesh );
 		final BitSet visited = new BitSet( nVertices );
@@ -122,9 +122,9 @@ public class MeshConnectedComponents
 	private static final TIntObjectHashMap< TIntArrayList > triangleMap( final Mesh mesh )
 	{
 		final Triangles triangles = mesh.triangles();
-		final int nTriangles = ( int ) triangles.size();
+		final int nTriangles = ( int ) triangles.sizel();
 		final Vertices vertices = mesh.vertices();
-		final int nVertices = ( int ) vertices.size();
+		final int nVertices = ( int ) vertices.sizel();
 
 		final TIntObjectHashMap< TIntArrayList > map = new TIntObjectHashMap<>( nVertices );
 		for ( int tid = 0; tid < nTriangles; tid++ )
@@ -166,7 +166,7 @@ public class MeshConnectedComponents
 		{
 			this.mesh = mesh;
 			this.map = triangleMap( mesh );
-			this.nVertices = ( int ) mesh.vertices().size();
+			this.nVertices = ( int ) mesh.vertices().sizel();
 			this.visited = new BitSet( nVertices );
 			this.currentStartVertex = 0;
 			this.next = prefetch();

--- a/src/main/java/net/imglib2/mesh/alg/MeshConnectedComponents.java
+++ b/src/main/java/net/imglib2/mesh/alg/MeshConnectedComponents.java
@@ -18,7 +18,7 @@ import net.imglib2.mesh.obj.nio.BufferMesh;
 
 /**
  * Connected components algorithm for meshes.
- * 
+ *
  * @author Jean-Yves Tinevez
  *
  */
@@ -27,7 +27,7 @@ public class MeshConnectedComponents
 
 	/**
 	 * Returns the number of connected components in this mesh.
-	 * 
+	 *
 	 * @param mesh
 	 *            the mesh.
 	 * @return the number of connected components.
@@ -36,7 +36,7 @@ public class MeshConnectedComponents
 	{
 		final Triangles triangles = mesh.triangles();
 		final Vertices vertices = mesh.vertices();
-		final int nVertices = ( int ) vertices.sizel();
+		final int nVertices = vertices.size();
 
 		final TIntObjectHashMap< TIntArrayList > map = triangleMap( mesh );
 		final BitSet visited = new BitSet( nVertices );
@@ -116,15 +116,15 @@ public class MeshConnectedComponents
 
 	/**
 	 * Returns the map of vertex id to the list of triangles they belong to.
-	 * 
+	 *
 	 * @param mesh
 	 */
 	private static final TIntObjectHashMap< TIntArrayList > triangleMap( final Mesh mesh )
 	{
 		final Triangles triangles = mesh.triangles();
-		final int nTriangles = ( int ) triangles.sizel();
+		final int nTriangles = triangles.size();
 		final Vertices vertices = mesh.vertices();
-		final int nVertices = ( int ) vertices.sizel();
+		final int nVertices = vertices.size();
 
 		final TIntObjectHashMap< TIntArrayList > map = new TIntObjectHashMap<>( nVertices );
 		for ( int tid = 0; tid < nTriangles; tid++ )
@@ -166,7 +166,7 @@ public class MeshConnectedComponents
 		{
 			this.mesh = mesh;
 			this.map = triangleMap( mesh );
-			this.nVertices = ( int ) mesh.vertices().sizel();
+			this.nVertices = mesh.vertices().size();
 			this.visited = new BitSet( nVertices );
 			this.currentStartVertex = 0;
 			this.next = prefetch();

--- a/src/main/java/net/imglib2/mesh/alg/MeshCursor.java
+++ b/src/main/java/net/imglib2/mesh/alg/MeshCursor.java
@@ -217,7 +217,7 @@ public class MeshCursor< T > implements Cursor< T >
 	@Override
 	public Cursor< T > copyCursor()
 	{
-		final BufferMesh dest = new BufferMesh( mesh.vertices().isize(), mesh.triangles().isize() );
+		final BufferMesh dest = new BufferMesh( mesh.vertices().size(), mesh.triangles().size() );
 		Meshes.copy( mesh, dest );
 		return new MeshCursor<>( ra.copyRandomAccess(), dest, cal.clone() );
 	}

--- a/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
+++ b/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
@@ -47,7 +47,7 @@ public class RemoveDuplicateVertices
 	public static Mesh calculate( final Mesh mesh, final int precision )
 	{
 		final Map< String, IndexedVertex > vertices = new LinkedHashMap<>();
-		final int[][] triangles = new int[ ( int ) mesh.triangles().size() ][ 3 ];
+		final int[][] triangles = new int[ ( int ) mesh.triangles().sizel() ][ 3 ];
 
 		int trianglesCount = 0;
 		for ( final net.imglib2.mesh.obj.Triangle triangle : mesh.triangles() )

--- a/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
+++ b/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -47,7 +47,7 @@ public class RemoveDuplicateVertices
 	public static Mesh calculate( final Mesh mesh, final int precision )
 	{
 		final Map< String, IndexedVertex > vertices = new LinkedHashMap<>();
-		final int[][] triangles = new int[ ( int ) mesh.triangles().sizel() ][ 3 ];
+		final int[][] triangles = new int[ mesh.triangles().size() ][ 3 ];
 
 		int trianglesCount = 0;
 		for ( final net.imglib2.mesh.obj.Triangle triangle : mesh.triangles() )

--- a/src/main/java/net/imglib2/mesh/alg/SimplifyMesh.java
+++ b/src/main/java/net/imglib2/mesh/alg/SimplifyMesh.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -237,9 +237,9 @@ public class SimplifyMesh
 		vertices.clear();
 		refs.clear();
 
-		final Point[] meshVerts = new Point[ ( int ) inMesh.vertices().sizel() ];
+		final Point[] meshVerts = new Point[ inMesh.vertices().size() ];
 		final Iterator< net.imglib2.mesh.obj.Vertex > iterator = inMesh.vertices().iterator();
-		for ( int i = 0; i < inMesh.vertices().sizel(); i++ )
+		for ( int i = 0; i < inMesh.vertices().size(); i++ )
 		{
 			final Point simpleVertex = new Point();
 			simpleVertex.setPosition( iterator.next() );
@@ -256,7 +256,7 @@ public class SimplifyMesh
 		int triIndex = 0;
 
 		final Iterator< net.imglib2.mesh.obj.Triangle > iteratorTriangles = inMesh.triangles().iterator();
-		for ( int i = 0; i < inMesh.triangles().sizel(); i++ )
+		for ( int i = 0; i < inMesh.triangles().size(); i++ )
 		{
 			final net.imglib2.mesh.obj.Triangle tria = iteratorTriangles.next();
 			final Triangle t = new Triangle(
@@ -315,7 +315,7 @@ public class SimplifyMesh
 		 * System.out.println(String.format("Simplify Target: %d of %d (%d%%)",
 		 * target_count, triangles.size(), target_count * 100 /
 		 * triangles.size()));
-		 * 
+		 *
 		 * final long timeStart = System.currentTimeMillis();
 		 */
 
@@ -435,7 +435,7 @@ public class SimplifyMesh
 		// ready
 		/*
 		 * long timeEnd = System.currentTimeMillis();
-		 * 
+		 *
 		 * System.out.println(String.
 		 * format("Simplify: %d/%d %d%% removed in %d ms", triangle_count -
 		 * deleted_triangles, triangle_count, deleted_triangles * 100 /

--- a/src/main/java/net/imglib2/mesh/alg/SimplifyMesh.java
+++ b/src/main/java/net/imglib2/mesh/alg/SimplifyMesh.java
@@ -237,9 +237,9 @@ public class SimplifyMesh
 		vertices.clear();
 		refs.clear();
 
-		final Point[] meshVerts = new Point[ ( int ) inMesh.vertices().size() ];
+		final Point[] meshVerts = new Point[ ( int ) inMesh.vertices().sizel() ];
 		final Iterator< net.imglib2.mesh.obj.Vertex > iterator = inMesh.vertices().iterator();
-		for ( int i = 0; i < inMesh.vertices().size(); i++ )
+		for ( int i = 0; i < inMesh.vertices().sizel(); i++ )
 		{
 			final Point simpleVertex = new Point();
 			simpleVertex.setPosition( iterator.next() );
@@ -256,7 +256,7 @@ public class SimplifyMesh
 		int triIndex = 0;
 
 		final Iterator< net.imglib2.mesh.obj.Triangle > iteratorTriangles = inMesh.triangles().iterator();
-		for ( int i = 0; i < inMesh.triangles().size(); i++ )
+		for ( int i = 0; i < inMesh.triangles().sizel(); i++ )
 		{
 			final net.imglib2.mesh.obj.Triangle tria = iteratorTriangles.next();
 			final Triangle t = new Triangle(
@@ -288,7 +288,7 @@ public class SimplifyMesh
 	public Mesh simplify( final float target_percent, final double agressiveness )
 	{
 
-		final int target_count = ( int ) ( inMesh.triangles().size() * target_percent );
+		final int target_count = ( int ) ( inMesh.triangles().sizel() * target_percent );
 		return simplify( target_count, agressiveness );
 	}
 

--- a/src/main/java/net/imglib2/mesh/alg/TaubinSmoothing.java
+++ b/src/main/java/net/imglib2/mesh/alg/TaubinSmoothing.java
@@ -85,8 +85,8 @@ public class TaubinSmoothing
 	public static final BufferMesh smooth( final Mesh mesh, final int iters, final double lambda, final double mu,
 			final TaubinWeightType weightType )
 	{
-		final int nvs = ( int ) mesh.vertices().size();
-		final int nts = ( int ) mesh.triangles().size();
+		final int nvs = ( int ) mesh.vertices().sizel();
+		final int nts = ( int ) mesh.triangles().sizel();
 		final BufferMesh meshA = new BufferMesh( nvs, nts );
 		Meshes.copy( mesh, meshA );
 		final BufferMesh meshB = new BufferMesh( nvs, nts );
@@ -114,7 +114,7 @@ public class TaubinSmoothing
 			throw new IllegalArgumentException( "Unhandled weight type: " + weightType );
 		}
 
-		final BufferMesh out = new BufferMesh( ( int ) meshA.vertices().size(), ( int ) meshA.triangles().size() );
+		final BufferMesh out = new BufferMesh( ( int ) meshA.vertices().sizel(), ( int ) meshA.triangles().sizel() );
 		Meshes.calculateNormals( meshA, out );
 		return out;
 	}
@@ -123,8 +123,8 @@ public class TaubinSmoothing
 			final double[] trace, final double weigth )
 	{
 
-		final int nvs = ( int ) source.vertices().size();
-		final int nts = ( int ) source.triangles().size();
+		final int nvs = ( int ) source.vertices().sizel();
+		final int nts = ( int ) source.triangles().sizel();
 
 		// Zero target.
 		for ( int i = 0; i < nvs; i++ )
@@ -205,8 +205,8 @@ public class TaubinSmoothing
 			final double[] trace, final double weigth )
 	{
 
-		final int nvs = ( int ) source.vertices().size();
-		final int nts = ( int ) source.triangles().size();
+		final int nvs = ( int ) source.vertices().sizel();
+		final int nts = ( int ) source.triangles().sizel();
 
 		// Zero target.
 		for ( int i = 0; i < nvs; i++ )

--- a/src/main/java/net/imglib2/mesh/alg/TaubinSmoothing.java
+++ b/src/main/java/net/imglib2/mesh/alg/TaubinSmoothing.java
@@ -13,7 +13,7 @@ import net.imglib2.mesh.obj.nio.BufferMesh;
  * <p>
  * Adapted by the Javascript code of mykolalysenko, MIT license.
  * https://github.com/mikolalysenko/taubin-smooth/blob/master/smooth.js
- * 
+ *
  * @author Jean-Yves Tinevez
  * @see <a href="https://doi.org/10.1109/ICCV.1995.466848">Taubin, G. “Curve and
  *      Surface Smoothing without Shrinkage.” In Proceedings of IEEE
@@ -26,7 +26,7 @@ public class TaubinSmoothing
 	/**
 	 * Smooth the specified mesh using the Taubin smoothing algorithm, with
 	 * default parameters.
-	 * 
+	 *
 	 * @param mesh
 	 *            the mesh to smooth.
 	 * @return a new smoothed mesh.
@@ -39,7 +39,7 @@ public class TaubinSmoothing
 	/**
 	 * Smooth the specified mesh using the Taubin smoothing algorithm, using
 	 * cotangent weights.
-	 * 
+	 *
 	 * @param mesh
 	 *            the mesh to smooth.
 	 * @param iters
@@ -66,7 +66,7 @@ public class TaubinSmoothing
 
 	/**
 	 * Smooth the specified mesh using the Taubin smoothing algorithm.
-	 * 
+	 *
 	 * @param mesh
 	 *            the mesh to smooth.
 	 * @param iters
@@ -85,8 +85,8 @@ public class TaubinSmoothing
 	public static final BufferMesh smooth( final Mesh mesh, final int iters, final double lambda, final double mu,
 			final TaubinWeightType weightType )
 	{
-		final int nvs = ( int ) mesh.vertices().sizel();
-		final int nts = ( int ) mesh.triangles().sizel();
+		final int nvs = mesh.vertices().size();
+		final int nts = mesh.triangles().size();
 		final BufferMesh meshA = new BufferMesh( nvs, nts );
 		Meshes.copy( mesh, meshA );
 		final BufferMesh meshB = new BufferMesh( nvs, nts );
@@ -114,7 +114,7 @@ public class TaubinSmoothing
 			throw new IllegalArgumentException( "Unhandled weight type: " + weightType );
 		}
 
-		final BufferMesh out = new BufferMesh( ( int ) meshA.vertices().sizel(), ( int ) meshA.triangles().sizel() );
+		final BufferMesh out = new BufferMesh( meshA.vertices().size(), meshA.triangles().size() );
 		Meshes.calculateNormals( meshA, out );
 		return out;
 	}
@@ -123,8 +123,8 @@ public class TaubinSmoothing
 			final double[] trace, final double weigth )
 	{
 
-		final int nvs = ( int ) source.vertices().sizel();
-		final int nts = ( int ) source.triangles().sizel();
+		final int nvs = source.vertices().size();
+		final int nts = source.triangles().size();
 
 		// Zero target.
 		for ( int i = 0; i < nvs; i++ )
@@ -205,8 +205,8 @@ public class TaubinSmoothing
 			final double[] trace, final double weigth )
 	{
 
-		final int nvs = ( int ) source.vertices().sizel();
-		final int nts = ( int ) source.triangles().sizel();
+		final int nvs = source.vertices().size();
+		final int nts = source.triangles().size();
 
 		// Zero target.
 		for ( int i = 0; i < nvs; i++ )

--- a/src/main/java/net/imglib2/mesh/alg/zslicer/ZSlicer.java
+++ b/src/main/java/net/imglib2/mesh/alg/zslicer/ZSlicer.java
@@ -67,9 +67,9 @@ public class ZSlicer
 		final Triangles triangles = mesh.triangles();
 		final Vertices vertices = mesh.vertices();
 
-		final double[] minZs = new double[ ( int ) triangles.size() ];
-		final double[] maxZs = new double[ ( int ) triangles.size() ];
-		for ( int t = 0; t < triangles.size(); t++ )
+		final double[] minZs = new double[ ( int ) triangles.sizel() ];
+		final double[] maxZs = new double[ ( int ) triangles.sizel() ];
+		for ( int t = 0; t < triangles.sizel(); t++ )
 		{
 			final long v0 = triangles.vertex0( t );
 			final long v1 = triangles.vertex1( t );
@@ -256,7 +256,7 @@ public class ZSlicer
 		final Vertices vertices = mesh.vertices();
 
 		final TIntArrayList intersecting = new TIntArrayList();
-		for ( long f = 0; f < triangles.size(); f++ )
+		for ( long f = 0; f < triangles.sizel(); f++ )
 		{
 			final long v0 = triangles.vertex0( f );
 			final long v1 = triangles.vertex1( f );

--- a/src/main/java/net/imglib2/mesh/alg/zslicer/ZSlicer.java
+++ b/src/main/java/net/imglib2/mesh/alg/zslicer/ZSlicer.java
@@ -67,9 +67,9 @@ public class ZSlicer
 		final Triangles triangles = mesh.triangles();
 		final Vertices vertices = mesh.vertices();
 
-		final double[] minZs = new double[ ( int ) triangles.sizel() ];
-		final double[] maxZs = new double[ ( int ) triangles.sizel() ];
-		for ( int t = 0; t < triangles.sizel(); t++ )
+		final double[] minZs = new double[ triangles.size() ];
+		final double[] maxZs = new double[ triangles.size() ];
+		for ( int t = 0; t < triangles.size(); t++ )
 		{
 			final long v0 = triangles.vertex0( t );
 			final long v1 = triangles.vertex1( t );

--- a/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
@@ -251,7 +251,7 @@ public class PLYMeshIO
 
 		// Write vertices
 		final TLongIntHashMap refToVertId = //
-				new TLongIntHashMap( ( int ) mesh.vertices().sizel() );
+				new TLongIntHashMap( mesh.vertices().size() );
 		int vertId = 0;
 		for ( final Vertex v : mesh.vertices() )
 		{
@@ -315,7 +315,7 @@ public class PLYMeshIO
 		}
 
 		// Write vertices
-		final TLongIntHashMap refToVertId = new TLongIntHashMap( ( int ) mesh.vertices().sizel() );
+		final TLongIntHashMap refToVertId = new TLongIntHashMap( mesh.vertices().size() );
 		int vertId = 0;
 		for ( final Vertex v : mesh.vertices() )
 		{

--- a/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
@@ -224,17 +224,17 @@ public class PLYMeshIO
 				"format binary_little_endian 1.0\n" + //
 				"comment This binary PLY mesh was created with imagej-mesh.\n";
 		final String vertexHeader = "" + //
-				"element vertex " + mesh.vertices().size() + "\n" + //
+				"element vertex " + mesh.vertices().sizel() + "\n" + //
 				"property float x\nproperty float y\nproperty float z\n" + //
 				"property float nx\nproperty float ny\nproperty float nz\n" + //
 				"property float u\nproperty float v\n";
-		final String triangleHeader = "element face " + mesh.triangles().size()
+		final String triangleHeader = "element face " + mesh.triangles().sizel()
 				+ "\nproperty list uchar int vertex_index\n";
 		final String endHeader = "end_header\n";
 		final long bytes = header.getBytes().length + //
 				vertexHeader.getBytes().length + triangleHeader.getBytes().length + endHeader.getBytes().length
-				+ mesh.vertices().size() * vertexBytes + //
-				mesh.triangles().size() * triangleBytes;
+				+ mesh.vertices().sizel() * vertexBytes + //
+				mesh.triangles().sizel() * triangleBytes;
 		if ( bytes > Integer.MAX_VALUE )
 			throw new IllegalArgumentException( "Mesh data too large: " + bytes );
 
@@ -246,12 +246,12 @@ public class PLYMeshIO
 		buffer.put( endHeader.getBytes() );
 
 		// Do not populate file if there are no vertices
-		if ( mesh.vertices().size() == 0 )
+		if ( mesh.vertices().sizel() == 0 )
 			return buffer.array();
 
 		// Write vertices
 		final TLongIntHashMap refToVertId = //
-				new TLongIntHashMap( ( int ) mesh.vertices().size() );
+				new TLongIntHashMap( ( int ) mesh.vertices().sizel() );
 		int vertId = 0;
 		for ( final Vertex v : mesh.vertices() )
 		{
@@ -282,21 +282,21 @@ public class PLYMeshIO
 	public static final byte[] writeAscii( final Mesh mesh ) throws IOException
 	{
 		final String header = "ply\nformat ascii 1.0\ncomment This binary PLY mesh was created with imagej-mesh.\n";
-		final String vertexHeader = "element vertex " + mesh.vertices().size()
+		final String vertexHeader = "element vertex " + mesh.vertices().sizel()
 				+ "\nproperty float x\nproperty float y\nproperty float z\nproperty float nx\nproperty float ny\nproperty float nz\nproperty float u\n property float v\n";
-		final String triangleHeader = "element face " + mesh.triangles().size()
+		final String triangleHeader = "element face " + mesh.triangles().sizel()
 				+ "\nproperty list uchar int vertex_index\n";
 		final String endHeader = "end_header\n";
 
 		// TODO: Fail fast more robustly if mesh is too large.
 		// But need to modify the API to not return a byte[].
-		if ( mesh.vertices().size() > Integer.MAX_VALUE )
+		if ( mesh.vertices().sizel() > Integer.MAX_VALUE )
 			throw new IllegalArgumentException( "Too many vertices: " + //
-					mesh.vertices().size() );
+					mesh.vertices().sizel() );
 
-		if ( mesh.triangles().size() > Integer.MAX_VALUE )
+		if ( mesh.triangles().sizel() > Integer.MAX_VALUE )
 			throw new IllegalArgumentException( "Too many triangles: " + //
-					mesh.triangles().size() );
+					mesh.triangles().sizel() );
 
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();
 
@@ -308,14 +308,14 @@ public class PLYMeshIO
 		writer.write( endHeader );
 
 		// Do not populate file if there are no vertices
-		if ( mesh.vertices().size() == 0 )
+		if ( mesh.vertices().sizel() == 0 )
 		{
 			writer.flush();
 			return os.toByteArray();
 		}
 
 		// Write vertices
-		final TLongIntHashMap refToVertId = new TLongIntHashMap( ( int ) mesh.vertices().size() );
+		final TLongIntHashMap refToVertId = new TLongIntHashMap( ( int ) mesh.vertices().sizel() );
 		int vertId = 0;
 		for ( final Vertex v : mesh.vertices() )
 		{

--- a/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
@@ -88,7 +88,7 @@ public class STLMeshIO
 	/** Writes the facets into a byte[] that can then be saved into a file */
 	public static final byte[] write( final Mesh mesh )
 	{
-		final long facetCount = mesh == null ? 0 : mesh.triangles().size();
+		final long facetCount = mesh == null ? 0 : mesh.triangles().sizel();
 		final long longBytes = HEADER_BYTES + COUNT_BYTES + facetCount * FACET_BYTES;
 		if ( longBytes > Integer.MAX_VALUE )
 		{ throw new IllegalArgumentException( "Too many triangles: " + facetCount ); }

--- a/src/main/java/net/imglib2/mesh/obj/Triangles.java
+++ b/src/main/java/net/imglib2/mesh/obj/Triangles.java
@@ -46,9 +46,9 @@ public interface Triangles extends Iterable< Triangle >
 	Mesh mesh();
 
 	/**
-	 * Number of triangles in the collection.
+	 * Number of triangles in the collection as a <code>long</code> value.
 	 */
-	long size();
+	long sizel();
 
 	/**
 	 * Number of triangles in the collection as an <code>int</code> value.
@@ -56,9 +56,9 @@ public interface Triangles extends Iterable< Triangle >
 	 * @throws RuntimeException
 	 *             if the number of triangles exceeds {@link Integer#MAX_VALUE}.
 	 */
-	default int isize()
+	default int size()
 	{
-		final long size = size();
+		final long size = sizel();
 		if ( size >= Integer.MAX_VALUE )
 			throw new RuntimeException( "Too many triangles: " + size );
 		return ( int ) size;
@@ -200,7 +200,7 @@ public interface Triangles extends Iterable< Triangle >
 	 *            Index of triangle's third vertex.
 	 * @return Index of newly added triangle.
 	 */
-	default long addf( long v0, long v1, long v2 )
+	default long addf( final long v0, final long v1, final long v2 )
 	{
 		// (v1 - v0) x (v2 - v0)
 
@@ -456,32 +456,6 @@ public interface Triangles extends Iterable< Triangle >
 	}
 
 	/**
-	 * Adds a triangle to the mesh's triangles list, using <code>int</code>
-	 * indices.
-	 * <p>
-	 * Normal is computed with counterclockwise (i.e., right-hand) orientation.
-	 * </p>
-	 *
-	 * @param v0
-	 *            Index of triangle's first vertex.
-	 * @param v1
-	 *            Index of triangle's second vertex.
-	 * @param v2
-	 *            Index of triangle's third vertex.
-	 * @return Index of newly added triangle.
-	 * @throws RuntimeException
-	 *             if the return triangle index exceeds
-	 *             {@link Integer#MAX_VALUE}.
-	 */
-	default int add( final int v0, final int v1, final int v2 )
-	{
-		final long t = add( ( long ) v0, ( long ) v1, ( long ) v2 );
-		if ( t >= Integer.MAX_VALUE )
-			throw new RuntimeException( "Index too large: " + t );
-		return ( int ) t;
-	}
-
-	/**
 	 * Adds a triangle to the mesh's triangles list.
 	 * <p>
 	 * This is a convenience method that first creates the vertices using
@@ -574,7 +548,7 @@ public interface Triangles extends Iterable< Triangle >
 
 			private long index = -1;
 
-			private Triangle triangle = new Triangle()
+			private final Triangle triangle = new Triangle()
 			{
 
 				@Override
@@ -593,7 +567,7 @@ public interface Triangles extends Iterable< Triangle >
 			@Override
 			public boolean hasNext()
 			{
-				return index + 1 < size();
+				return index + 1 < sizel();
 			}
 
 			@Override

--- a/src/main/java/net/imglib2/mesh/obj/Vertices.java
+++ b/src/main/java/net/imglib2/mesh/obj/Vertices.java
@@ -43,8 +43,8 @@ public interface Vertices extends Iterable< Vertex >
 	/** The mesh to which the collection of vertices belongs. */
 	Mesh mesh();
 
-	/** Number of vertices in the collection. */
-	long size();
+	/** Number of vertices in the collection as a <code>long</code> value. */
+	long sizel();
 
 	/**
 	 * Number of vertices in the collection as an <code>int</code> value.
@@ -52,9 +52,9 @@ public interface Vertices extends Iterable< Vertex >
 	 * @throws RuntimeException
 	 *             if the number of vertices exceed {@link Integer#MAX_VALUE}.
 	 */
-	default int isize()
+	default int size()
 	{
-		final long size = size();
+		final long size = sizel();
 		if ( size >= Integer.MAX_VALUE )
 			throw new RuntimeException( "Too many vertices: " + size );
 		return ( int ) size;
@@ -133,11 +133,11 @@ public interface Vertices extends Iterable< Vertex >
 	 * @throws RuntimeException
 	 *             if the number of vertices exceed {@link Integer#MAX_VALUE}.
 	 */
-	default int addfi( float x, float y, float z, //
-			float nx, float ny, float nz, //
-			float u, float v )
+	default int addfi( final float x, final float y, final float z, //
+			final float nx, final float ny, final float nz, //
+			final float u, final float v )
 	{
-		long vi = addf( x, y, z, nx, ny, nz, u, v );
+		final long vi = addf( x, y, z, nx, ny, nz, u, v );
 		if ( vi >= Integer.MAX_VALUE )
 			throw new RuntimeException( "Too many vertices: " + vi );
 		return ( int ) vi;
@@ -300,13 +300,13 @@ public interface Vertices extends Iterable< Vertex >
 	}
 
 	/** U value of vertex texture coordinate, as a double. */
-	default double u( long vIndex )
+	default double u( final long vIndex )
 	{
 		return uf( vIndex );
 	}
 
 	/** V value of vertex texture coordinate, as a double. */
-	default double v( long vIndex )
+	default double v( final long vIndex )
 	{
 		return vf( vIndex );
 	}
@@ -367,9 +367,9 @@ public interface Vertices extends Iterable< Vertex >
 	 *            V value of vertex texture coordinate.
 	 * @return Index of newly added vertex.
 	 */
-	default long add( double x, double y, double z, //
-			double nx, double ny, double nz, //
-			double u, double v )
+	default long add( final double x, final double y, final double z, //
+			final double nx, final double ny, final double nz, //
+			final double u, final double v )
 	{
 		return addf( ( float ) x, ( float ) y, ( float ) z, //
 				( float ) nx, ( float ) ny, ( float ) nz, //
@@ -400,9 +400,9 @@ public interface Vertices extends Iterable< Vertex >
 	 * @throws RuntimeException
 	 *             if the number of vertices exceed {@link Integer#MAX_VALUE}.
 	 */
-	default int addi( double x, double y, double z, //
-			double nx, double ny, double nz, //
-			double u, double v )
+	default int addi( final double x, final double y, final double z, //
+			final double nx, final double ny, final double nz, //
+			final double u, final double v )
 	{
 		return addfi( ( float ) x, ( float ) y, ( float ) z, //
 				( float ) nx, ( float ) ny, ( float ) nz, //
@@ -521,7 +521,7 @@ public interface Vertices extends Iterable< Vertex >
 
 			private long index = -1;
 
-			private Vertex vertex = new Vertex()
+			private final Vertex vertex = new Vertex()
 			{
 
 				@Override
@@ -540,7 +540,7 @@ public interface Vertices extends Iterable< Vertex >
 			@Override
 			public boolean hasNext()
 			{
-				return index + 1 < size();
+				return index + 1 < sizel();
 			}
 
 			@Override

--- a/src/main/java/net/imglib2/mesh/obj/naive/NaiveDoubleMesh.java
+++ b/src/main/java/net/imglib2/mesh/obj/naive/NaiveDoubleMesh.java
@@ -90,7 +90,7 @@ public class NaiveDoubleMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return xs.size();
 		}
@@ -317,7 +317,7 @@ public class NaiveDoubleMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return v1s.size();
 		}

--- a/src/main/java/net/imglib2/mesh/obj/naive/NaiveFloatMesh.java
+++ b/src/main/java/net/imglib2/mesh/obj/naive/NaiveFloatMesh.java
@@ -90,7 +90,7 @@ public class NaiveFloatMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return xs.size();
 		}
@@ -235,7 +235,7 @@ public class NaiveFloatMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return v1s.size();
 		}

--- a/src/main/java/net/imglib2/mesh/obj/nio/BufferMesh.java
+++ b/src/main/java/net/imglib2/mesh/obj/nio/BufferMesh.java
@@ -140,7 +140,7 @@ public class BufferMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return verts.limit() / V_STRIDE;
 		}
@@ -197,7 +197,7 @@ public class BufferMesh implements Mesh
 		public long addf( float x, float y, float z, float nx, float ny, float nz,
 				float u, float v )
 		{
-			final long index = size();
+			final long index = sizel();
 			grow( verts, V_STRIDE );
 			verts.put( x );
 			verts.put( y );
@@ -287,7 +287,7 @@ public class BufferMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
 			return indices.limit() / I_STRIDE;
 		}
@@ -331,7 +331,7 @@ public class BufferMesh implements Mesh
 		@Override
 		public long addf( long v0, long v1, long v2, float nx, float ny, float nz )
 		{
-			final long index = size();
+			final long index = sizel();
 			grow( indices, I_STRIDE );
 			indices.put( safeInt( v0 ) );
 			indices.put( safeInt( v1 ) );

--- a/src/main/java/net/imglib2/mesh/obj/transform/TranslateMesh.java
+++ b/src/main/java/net/imglib2/mesh/obj/transform/TranslateMesh.java
@@ -121,7 +121,7 @@ public class TranslateMesh implements Mesh
 				@Override
 				public boolean hasNext()
 				{
-					return index + 1 < size();
+					return index + 1 < sizel();
 				}
 
 				@Override
@@ -140,9 +140,9 @@ public class TranslateMesh implements Mesh
 		}
 
 		@Override
-		public long size()
+		public long sizel()
 		{
-			return invs.size();
+			return invs.sizel();
 		}
 
 		@Override

--- a/src/test/java/net/imglib2/mesh/AbstractMeshTest.java
+++ b/src/test/java/net/imglib2/mesh/AbstractMeshTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractMeshTest
 				t0v2x, t0v2y, t0v2z, //
 				t0nx, t0ny, t0nz ); //
 
-		assertEquals( 3, mesh.vertices().size() );
+		assertEquals( 3, mesh.vertices().sizel() );
 
 		final double t1v0x = 13, t1v0y = 14, t1v0z = 15;
 		final double t1v1x = 16, t1v1y = 17, t1v1z = 18;
@@ -89,7 +89,7 @@ public abstract class AbstractMeshTest
 				t1v2x, t1v2y, t1v2z, //
 				t1nx, t1ny, t1nz ); //
 
-		assertEquals( 6, mesh.vertices().size() );
+		assertEquals( 6, mesh.vertices().sizel() );
 
 		final double t2v0x = 25, t2v0y = 26, t2v0z = 27;
 		final double t2v1x = 28, t2v1y = 29, t2v1z = 30;
@@ -100,7 +100,7 @@ public abstract class AbstractMeshTest
 		final long t2v2 = mesh.vertices().add( t2v2x, t2v2y, t2v2z );
 		final long t2 = mesh.triangles().add( t2v0, t2v1, t2v2, t2nx, t2ny, t2nz );
 
-		assertEquals( 9, mesh.vertices().size() );
+		assertEquals( 9, mesh.vertices().sizel() );
 		assertVertex( mesh, 0, t0v0x, t0v0y, t0v0z );
 		assertVertex( mesh, 1, t0v1x, t0v1y, t0v1z );
 		assertVertex( mesh, 2, t0v2x, t0v2y, t0v2z );
@@ -111,7 +111,7 @@ public abstract class AbstractMeshTest
 		assertVertex( mesh, 7, t2v1x, t2v1y, t2v1z );
 		assertVertex( mesh, 8, t2v2x, t2v2y, t2v2z );
 
-		assertEquals( 3, mesh.triangles().size() );
+		assertEquals( 3, mesh.triangles().sizel() );
 		final Set< Long > vertexIndices = new HashSet<>();
 		assertTriangle( mesh, vertexIndices, 0, //
 				t0v0x, t0v0y, t0v0z, //
@@ -167,10 +167,10 @@ public abstract class AbstractMeshTest
 		lazyInputMesh.vertices().add( 1, 0, -1 );
 		lazyInputMesh.triangles().add( 0, 1, 2 );
 
-		Mesh outMesh = new BufferMesh( ( int ) inputMesh.vertices().size(), ( int ) inputMesh.triangles().size() );
+		Mesh outMesh = new BufferMesh( ( int ) inputMesh.vertices().sizel(), ( int ) inputMesh.triangles().sizel() );
 		Meshes.calculateNormals( inputMesh, outMesh );
 
-		for ( int idx = 0; idx < inputMesh.triangles().size(); idx++ )
+		for ( int idx = 0; idx < inputMesh.triangles().sizel(); idx++ )
 		{
 			// calculateNormals test
 			assertTriangleNormal( inputMesh, 0, outMesh.triangles().nx( idx ), outMesh.triangles().ny( idx ), outMesh.triangles().nz( idx ) );

--- a/src/test/java/net/imglib2/mesh/MeshesTest.java
+++ b/src/test/java/net/imglib2/mesh/MeshesTest.java
@@ -83,7 +83,7 @@ public class MeshesTest
 		Mesh mesh = createMeshWithNoise();
 
 		Mesh res = Meshes.removeDuplicateVertices( mesh, 2 );
-		assertEquals( 4, res.vertices().size() );
+		assertEquals( 4, res.vertices().sizel() );
 
 		assertEquals( p1.getDoublePosition( 0 ), res.vertices().x( 0 ), EPSILON );
 		assertEquals( p1.getDoublePosition( 1 ), res.vertices().y( 0 ), EPSILON );
@@ -102,7 +102,7 @@ public class MeshesTest
 		assertEquals( p4.getDoublePosition( 2 ), res.vertices().z( 3 ), EPSILON );
 
 		res = Meshes.removeDuplicateVertices( mesh, 3 );
-		assertEquals( 6, res.vertices().size() );
+		assertEquals( 6, res.vertices().sizel() );
 	}
 
 	@Test
@@ -111,7 +111,7 @@ public class MeshesTest
 		LabelRegion< String > ROI = createLabelRegion( getTestImage3D(), 1, 255 );
 		Mesh mesh = getMesh();
 		final Mesh result = Meshes.marchingCubes( ROI );
-		assertEquals( mesh.triangles().size(), result.triangles().size() );
+		assertEquals( mesh.triangles().sizel(), result.triangles().sizel() );
 		final Iterator< Triangle > expectedFacets = mesh.triangles().iterator();
 		final Iterator< Triangle > actualFacets = result.triangles().iterator();
 		while ( expectedFacets.hasNext() && actualFacets.hasNext() )
@@ -137,7 +137,7 @@ public class MeshesTest
 		LabelRegion< String > ROI = createLabelRegion( getTestImage3D(), 1, 255 );
 		Mesh mesh = getMesh();
 		final Mesh result = Meshes.marchingCubes( ROI, 1.0 );
-		assertEquals( mesh.triangles().size(), result.triangles().size() );
+		assertEquals( mesh.triangles().sizel(), result.triangles().sizel() );
 		final Iterator< Triangle > expectedFacets = mesh.triangles().iterator();
 		final Iterator< Triangle > actualFacets = result.triangles().iterator();
 		while ( expectedFacets.hasNext() && actualFacets.hasNext() )

--- a/src/test/java/net/imglib2/mesh/alg/MeshCursorTest.java
+++ b/src/test/java/net/imglib2/mesh/alg/MeshCursorTest.java
@@ -109,7 +109,7 @@ public class MeshCursorTest
 		// Build a mesh from the source image..
 		final Mesh m = Meshes.marchingCubes( img, expected / 2. );
 		final Mesh m2 = Meshes.removeDuplicateVertices( m, 2 );
-		final BufferMesh mesh = new BufferMesh( m2.vertices().isize(), m2.triangles().isize() );
+		final BufferMesh mesh = new BufferMesh( m2.vertices().size(), m2.triangles().size() );
 		Meshes.calculateNormals( m2, mesh );
 
 		// Test we are iterating strictly inside the cube.

--- a/src/test/java/net/imglib2/mesh/alg/TaubinSmoothingDemo.java
+++ b/src/test/java/net/imglib2/mesh/alg/TaubinSmoothingDemo.java
@@ -30,7 +30,7 @@ public class TaubinSmoothingDemo
 
 		// Add noise.
 		final Random ran = new Random( 45l );
-		for ( int i = 0; i < mesh.vertices().size(); i++ )
+		for ( int i = 0; i < mesh.vertices().sizel(); i++ )
 		{
 			final double x = mesh.vertices().x( i );
 			final double y = mesh.vertices().y( i );


### PR DESCRIPTION
Now the sizel() method returns a long. This should make it possible for a Vertices and Triangles implementation to implement a Mastodon interface.